### PR TITLE
Add `<meta charset="utf-8">` to HTML files

### DIFF
--- a/articles/dsalien.html
+++ b/articles/dsalien.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>DSAlien</title>
         <link rel="stylesheet" href="../css/article-dark.css">
         <link rel="stylesheet" href="../css/highlight/styles/night-owl.min.css">

--- a/articles/hidden.html
+++ b/articles/hidden.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>Crackmes.one: Hidden Password</title>
         <link rel="stylesheet" href="../css/article-light.css">
         <link rel="stylesheet" href="../css/highlight/styles/github.min.css">

--- a/articles/hole.html
+++ b/articles/hole.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>HITCON 2021: Hole</title>
         <link rel="stylesheet" href="../css/article-dark.css">
         <link rel="stylesheet" href="../css/highlight/styles/night-owl.min.css">

--- a/articles/vsock.html
+++ b/articles/vsock.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>Linux Kernel Exploitation: CVE-2025-21756</title>
         <link rel="stylesheet" href="../css/article-dark.css">
         <link rel="stylesheet" href="../css/highlight/styles/github-dark.min.css">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>Adventures in Hacking</title>
         <link rel="stylesheet" href="css/main.css">
         <script src="https://cdn.jsdelivr.net/npm/p5@1.5.0/lib/p5.js"></script>


### PR DESCRIPTION
The pages are being detected as `document.charset === "windows-1252"`. This causes corruption for unicode characters, e.g., "We’ve Got a Panic!" displays as "Weâ€™ve Got a Panic!" in `vsock.html` in my Firefox on macOS.

Adding an explicit meta tag is a reasonable fix. An alternative would be fixing the HTTP server to include the charset in the Content-Type header, but adding a meta tag is more explicit.